### PR TITLE
Fix compilation of Boost.WinAPI-based Boost.Thread

### DIFF
--- a/include/boost/thread/win32/basic_recursive_mutex.hpp
+++ b/include/boost/thread/win32/basic_recursive_mutex.hpp
@@ -44,13 +44,13 @@ namespace boost
 
             bool try_lock() BOOST_NOEXCEPT
             {
-                long const current_thread_id=win32::GetCurrentThreadId();
+                long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 return try_recursive_lock(current_thread_id) || try_basic_lock(current_thread_id);
             }
 
             void lock()
             {
-                long const current_thread_id=win32::GetCurrentThreadId();
+                long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 if(!try_recursive_lock(current_thread_id))
                 {
                     mutex.lock();
@@ -61,7 +61,7 @@ namespace boost
 #if defined BOOST_THREAD_USES_DATETIME
             bool timed_lock(::boost::system_time const& target)
             {
-                long const current_thread_id=win32::GetCurrentThreadId();
+                long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 return try_recursive_lock(current_thread_id) || try_timed_lock(current_thread_id,target);
             }
             template<typename Duration>
@@ -75,13 +75,13 @@ namespace boost
         template <class Rep, class Period>
         bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
         {
-                long const current_thread_id=win32::GetCurrentThreadId();
+                long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 return try_recursive_lock(current_thread_id) || try_timed_lock_for(current_thread_id,rel_time);
         }
         template <class Clock, class Duration>
         bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
         {
-                long const current_thread_id=win32::GetCurrentThreadId();
+                long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 return try_recursive_lock(current_thread_id) || try_timed_lock_until(current_thread_id,t);
         }
 #endif

--- a/include/boost/thread/win32/thread_primitives.hpp
+++ b/include/boost/thread/win32/thread_primitives.hpp
@@ -25,6 +25,7 @@
 #include <boost/detail/winapi/event.hpp>
 #include <boost/detail/winapi/thread.hpp>
 #include <boost/detail/winapi/get_current_thread.hpp>
+#include <boost/detail/winapi/get_current_thread_id.hpp>
 #include <boost/detail/winapi/get_current_process.hpp>
 #include <boost/detail/winapi/get_current_process_id.hpp>
 #include <boost/detail/winapi/wait.hpp>


### PR DESCRIPTION
These fixes are needed to compile Boost.Thread tests with MSVC 8-14.1 and MinGW.